### PR TITLE
Unnamed Providers

### DIFF
--- a/docs/reference/core/providers/provider.md
+++ b/docs/reference/core/providers/provider.md
@@ -18,7 +18,6 @@ created before calling `prvd.start(options)`.
 
     ```Lua
     function prvd.Provider<T>(
-      name: string,
       provider: T
     ): Provider<T>
     ```
@@ -32,7 +31,7 @@ created before calling `prvd.start(options)`.
         local prvd = require(ReplicatedStorage.Packages.ohmyprvd)
 
         local PointsProvider = {}
-        return prvd.new("PointsProvider", PointsProvider)
+        return prvd.new(PointsProvider)
         ```
 
         For consistency, we recommend using `Provider` when favorable, as
@@ -42,7 +41,6 @@ created before calling `prvd.start(options)`.
 
     ```TypeScript
     export const Provider: <T extends object>(
-      name: string,
       provider: T
     ) => Provider<T>
     ```
@@ -50,10 +48,6 @@ created before calling `prvd.start(options)`.
 ---
 
 ## Parameters
-
-### name `#!lua : string`
-
-A unique name to identify the provider with. This will be used for debugging.
 
 ### provider `#!lua : T`
 

--- a/docs/reference/error-messages.md
+++ b/docs/reference/error-messages.md
@@ -52,10 +52,9 @@ You attempted to register a new provider, but Oh My Prvd caught something wrong.
 The error includes a more specific message which can be used to diagnose the
 issue. Typically it is one of the following:
 
-- A provider of the same name was already registered
+- This provider has already been registered
 - You have frozen the provider table, which prevents dependency injection
 - You provided a mismatched type for a built-in method/property
-- You forgot to include a non-empty string as a `name`
 
 ---
 

--- a/docs/tutorials/fundamentals/providers.md
+++ b/docs/tutorials/fundamentals/providers.md
@@ -18,7 +18,7 @@ lifecycle events:
     local prvd = require(ReplicatedStorage.Packages.ohmyprvd)
 
     local PointsProvider = {}
-    return prvd.Provider("PointsProvider", PointsProvider)
+    return prvd.Provider(PointsProvider)
     ```
 
 === "TypeScript"
@@ -26,7 +26,7 @@ lifecycle events:
     ```TypeScript
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("PointsProvider", {})
+    export = Provider({})
     ```
 
 ??? tip "Too verbose?"
@@ -39,7 +39,7 @@ lifecycle events:
     local prvd = require(ReplicatedStorage.Packages.ohmyprvd)
 
     local PointsProvider = {}
-    return prvd.new("PointsProvider", PointsProvider)
+    return prvd.new(PointsProvider)
     ```
 
     For consistency, we recommend using `Provider` when favorable.
@@ -72,7 +72,7 @@ a `Player` and their points:
     local PointsProvider = {}
     PointsProvider.points = {}
 
-    return prvd.Provider("PointsProvider", PointsProvider)
+    return prvd.Provider(PointsProvider)
     ```
 
 === "TypeScript"
@@ -80,7 +80,7 @@ a `Player` and their points:
     ```TypeScript hl_lines="4"
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("PointsProvider", {
+    export = Provider({
       points: Map<Player, number> = {}
     })
     ```
@@ -107,7 +107,7 @@ for convenience:
       self.points[player] = 10
     end
 
-    return prvd.Provider("PointsProvider", PointsProvider)
+    return prvd.Provider(PointsProvider)
     ```
 
 === "TypeScript"
@@ -115,7 +115,7 @@ for convenience:
     ```TypeScript hl_lines="6-8"
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("PointsProvider", {
+    export = Provider({
       points: Map<Player, number> = {}
 
       setDefaultPoints(player: Player) {
@@ -243,7 +243,7 @@ every player that joins:
       end
     end
 
-    return prvd.Provider("PointsProvider", PointsProvider)
+    return prvd.Provider(PointsProvider)
     ```
 
 === "TypeScript"
@@ -252,7 +252,7 @@ every player that joins:
     import { Provider } from "@rbxts/ohmyprvd"
     import { Players } from "@rbxts/services"
 
-    export = Provider("PointsProvider", {
+    export = Provider({
       points: Map<Player, number> = {},
 
       setDefaultPoints(player: Player) {
@@ -316,7 +316,7 @@ function PointsProvider.start(
   end)
 end
 
-return prvd.Provider("PointsProvider", PointsProvider)
+return prvd.Provider(PointsProvider)
 ```
 
 ---
@@ -347,7 +347,7 @@ First, create a file for a new `MathProvider` with the following:
       return a + b
     end
 
-    return prvd.Provider("MathProvider", MathProvider)
+    return prvd.Provider(MathProvider)
     ```
 
 === "TypeScript"
@@ -355,7 +355,7 @@ First, create a file for a new `MathProvider` with the following:
     ```TypeScript
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("MathProvider", {
+    export = Provider({
       add(a: number, b: number) {
         // this method is very expensive!
         task.wait(5)
@@ -417,7 +417,7 @@ function PointsProvider.addPoints(
   )
 end
 
-return prvd.Provider("PointsProvider", PointsProvider)
+return prvd.Provider(PointsProvider)
 ```
 
 ??? danger "Do not use dependencies outside of lifecycle methods!"

--- a/packages/ohmyprvd/lib/prvd.luau
+++ b/packages/ohmyprvd/lib/prvd.luau
@@ -69,7 +69,7 @@ local awaitingThreads: { [thread]: true } = setmetatable({} :: any, WEAK_KEYS_ME
 local awaitingCallbacks: { () -> () } = {}
 local status: StartupStatus = StartupStatus.Pending
 
-local providers: { [string]: Provider<any> } = {}
+local providers: { [Provider<any>]: string } = {}
 local startupOptions: Options? = nil
 
 local prvd = {}
@@ -132,27 +132,25 @@ end
   Constructs and returns a new provider within Oh My Prvd. Providers must be
   created before calling `Prvd.start()`.
 ]]
-function prvd.Provider<T>(name: string, provider: T): Provider<T>
+function prvd.Provider<T>(provider: T): Provider<T>
   expect(status == StartupStatus.Pending, "registerAfterStarted")
-  expect(typeof(name) == "string", "cannotRegister", nil, "`name` must be a string")
-  expect(name:len() > 0, "cannotRegister", nil, "`name` cannot be empty")
   expect(typeof(provider) == "table", "cannotRegister", nil, "provider must be a table")
   expect(not table.isfrozen(provider :: any), "cannotRegister", nil, "provider cannot be frozen")
-  expect(providers[name] == nil, "cannotRegister", nil, `already registered "{name}"`)
 
+  local source: string = debug.info(2, "s")
   local provider = table.clone(provider :: Provider<T>) :: Provider<T>
   for method, expectedType in pairs(EXPECTED_METHOD_TYPES) do
     if (provider :: any)[method] == nil then
       continue
     end
     local realType = typeof((provider :: any)[method])
-    expect(expectedType == realType, "cannotRegister", `\`{name}.{method}\` should be a {expectedType}`)
+    expect(expectedType == realType, "cannotRegister", `\`{method}\` should be a {expectedType}`)
   end
 
   reflect.defineMetadata(provider, "ohmyprvd:provider", true)
-  reflect.defineMetadata(provider, "identifier", name)
+  reflect.defineMetadata(provider, "identifier", source)
   reflect.defineMetadata(provider, "ohmyprvd:loadOrder", provider.loadOrder)
-  providers[name] = provider
+  providers[provider] = source
   modding.doProviderConstructed(provider)
   return provider
 end
@@ -163,7 +161,7 @@ end
 ]]
 function prvd.use<T>(provider: Provider<T>): T
   expect(status == StartupStatus.Pending, "useAfterStarted")
-  expect(providers[getIdentifier(provider)] ~= nil, "cannotUseNonProvider")
+  expect(providers[provider] ~= nil, "cannotUseNonProvider")
   local identifier = getIdentifier(provider)
   modding.doProviderUsed(provider)
   return setmetatable(
@@ -225,7 +223,7 @@ function prvd.start(options: {
     }
   } = {}
 
-  for _, provider in pairs(providers) do
+  for provider in pairs(providers) do
     table.insert(dependencies, {
       instance = provider,
       loadOrder = provider.loadOrder or 1,

--- a/packages/ohmyprvd/lib/prvd.luau
+++ b/packages/ohmyprvd/lib/prvd.luau
@@ -135,6 +135,7 @@ end
 function prvd.Provider<T>(provider: T): Provider<T>
   expect(status == StartupStatus.Pending, "registerAfterStarted")
   expect(typeof(provider) == "table", "cannotRegister", nil, "provider must be a table")
+  expect(not providers[provider], "cannotRegister", nil, "already registered provider")
   expect(not table.isfrozen(provider :: any), "cannotRegister", nil, "provider cannot be frozen")
 
   local source: string = debug.info(2, "s")
@@ -156,8 +157,8 @@ function prvd.Provider<T>(provider: T): Provider<T>
 end
 
 --[[
-  Uses a provider within Oh My Prvd. During startup, Oh My Prvd will inject
-  the dependencies your provider uses.
+  Uses a provider within Oh My Prvd. During startup, Oh My Prvd will inject the
+  dependencies your provider uses.
 ]]
 function prvd.use<T>(provider: Provider<T>): T
   expect(status == StartupStatus.Pending, "useAfterStarted")

--- a/packages/ohmyprvd/lib/types.luau
+++ b/packages/ohmyprvd/lib/types.luau
@@ -92,9 +92,9 @@ export type Prvd = {
     Starting: "StartupStatus.Starting",
     Startup: "StartupStatus.Started",
   },
-  new: <T>(name: string, provider: T) -> Provider<T>,
+  new: <T>(provider: T) -> Provider<T>,
   onStart: (callback: () -> ()) -> (),
-  Provider: <T>(name: string, provider: T) -> Provider<T>,
+  Provider: <T>(provider: T) -> Provider<T>,
   use: <T>(provider: Provider<T>) -> T,
 
   onMethodImplemented: (method: string, handler: (Provider<unknown>) -> ()) -> (),


### PR DESCRIPTION
Solves #4. Drops the `name` field in `prvd.new` and `prvd.Provider` in favor of using `debug.info(2, "s")`.