### PR TITLE
Provider Decorator

### DIFF
--- a/docs/reference/core/providers/new.md
+++ b/docs/reference/core/providers/new.md
@@ -1,0 +1,62 @@
+<div class="ompdoc-reference-breadcrumbs">
+<a href="../../../">Reference</a>
+<a href="../../">Core</a>
+<a href="../">Providers</a>
+</div>
+
+<div class="ompdoc-reference-tags">
+<span>function</span>
+<span>since v0.1</span>
+</div>
+
+# prvd.new
+
+Constructs and returns a new [provider](../types/provider.md) within Oh My Prvd. Providers must be
+created before calling `prvd.start(options)`.
+
+```Lua
+function prvd.new<T>(
+  name: string,
+  provider: T
+): Provider<T>
+```
+
+!!! warning "Know the difference"
+
+    This and [`@Provider(options)`](provider.md) seems to serve the same
+    purpose. This is used as a function, ideal for Luau. Contrast to
+    [`@Provider(options)`](provider.md), which ideal to be used as a class
+    decorator for Roblox TypeScript.
+
+---
+
+## Parameters
+
+### name `#!lua : string`
+
+A unique name to identify the provider with. This will be used for debugging.
+
+### provider `#!lua : T`
+
+The methods and properties of the provider. Oh My Prvd provides two lifecycle
+methods out of the box which may be specified:
+
+- `:onInit` runs sequentially before any other lifecycle methods, methods are
+  expected to be infallible and preferably non-yielding.
+- `:onStart` runs concurrently *after* all other lifecycle methods have been
+  registered. This means failures and yields do not affect other providers.
+
+In addition, the provider may also specify a `loadOrder` property which
+dictates when the provider is loaded, defaults to one.
+
+---
+
+## Returns `#!lua : Provider<T>`
+
+A freshly registered provider.
+
+---
+
+## Learn More
+
+- [Providers tutorial](../../../tutorials/fundamentals/providers.md)

--- a/docs/reference/core/providers/provider.md
+++ b/docs/reference/core/providers/provider.md
@@ -5,74 +5,49 @@
 </div>
 
 <div class="ompdoc-reference-tags">
-<span>function</span>
-<span>since v0.1</span>
+<span>decorator</span>
+<span>since v0.2</span>
 </div>
 
-# Provider
+# prvd.Provider
 
-Constructs and returns a new [provider](../types/provider.md) within Oh My Prvd. Providers must be
-created before calling `prvd.start(options)`.
+Constructs and returns a new class decorator that registers a
+[provider](../types/provider.md) within Oh My Prvd. Providers must be created
+before calling `prvd.start(options)`.
 
-=== "Luau"
+```TypeScript
+export const Provider: (options?: {
+  loadOrder?: number
+}) => <T extends new () => InstanceType<T>>(provider: T) => void
+```
 
-    ```Lua
-    function prvd.Provider<T>(
-      name: string,
-      provider: T
-    ): Provider<T>
-    ```
+!!! warning "Know the difference"
 
-    ??? tip "Too verbose?"
-
-        If writing `#!lua prvd.Provider` sounds verbose for you, Oh My Prvd
-        aliases the `Provider` constructor with `new`:
-
-        ```Lua
-        local prvd = require(ReplicatedStorage.Packages.ohmyprvd)
-
-        local PointsProvider = {}
-        return prvd.new("PointsProvider", PointsProvider)
-        ```
-
-        For consistency, we recommend using `Provider` when favorable, as
-        `new` is a reserved keyword in TypeScript.
-
-=== "TypeScript"
-
-    ```TypeScript
-    export const Provider: <T extends object>(
-      name: string,
-      provider: T
-    ) => Provider<T>
-    ```
+    This and [`prvd.new(name, provider)`](new.md) seems to serve the same
+    purpose. This is used as a class decorator, ideal for Roblox TypeScript.
+    Contrast to [`prvd.new(name, provider)`](new.md), which ideal to be used as
+    a function for Luau.
 
 ---
 
 ## Parameters
 
-### name `#!lua : string`
+### options `#!TypeScript : string`
 
-A unique name to identify the provider with. This will be used for debugging.
+Options to instantiate the provider with:
 
-### provider `#!lua : T`
-
-The methods and properties of the provider. Oh My Prvd provides two lifecycle
-methods out of the box which may be specified:
-
-- `:onInit` runs sequentially before any other lifecycle methods, methods are
-  expected to be infallible and preferably non-yielding.
-- `:onStart` runs concurrently *after* all other lifecycle methods have been
-  registered. This means failures and yields do not affect other providers.
-
-In addition, the provider may also specify a `loadOrder` property which
-dictates when the provider is loaded, defaults to one.
+- `#!TypeScript loadOrder : number` can be specified as a shorthand for adding a
+  loadOrder field.
 
 ---
 
-## Returns `#!lua : Provider<T>`
+## Returns `#!TypeScript : <...>(provider: T) => void`
 
-A freshly registered provider.
+A decorator that, when used on a class, registers it as a
+[provider](../types/provider.md) within Oh My Prvd.
+
+Note that the identifier is inferred from it's `__tostring` metamethod, which
+should be appended by the Roblox TypeScript compiler.
 
 ---
 

--- a/docs/reference/error-messages.md
+++ b/docs/reference/error-messages.md
@@ -46,7 +46,7 @@ cannot register provider; `MyProvider.onStart` should be a function
 ```
 
 **Thrown by:** [`prvd.Provider`](core/providers/provider.md),
-[`prvd.new`](core/providers/provider.md)
+[`prvd.new`](core/providers/new.md)
 
 You attempted to register a new provider, but Oh My Prvd caught something wrong.
 The error includes a more specific message which can be used to diagnose the
@@ -104,7 +104,7 @@ cannot register providers after startup
 ```
 
 **Thrown by:** [`prvd.Provider`](core/providers/provider.md),
-[`prvd.new`](core/providers/provider.md)
+[`prvd.new`](core/providers/new.md)
 
 You attempted to register a provider after startup.
 

--- a/docs/tutorials/fundamentals/providers.md
+++ b/docs/tutorials/fundamentals/providers.md
@@ -18,7 +18,7 @@ lifecycle events:
     local prvd = require(ReplicatedStorage.Packages.ohmyprvd)
 
     local PointsProvider = {}
-    return prvd.Provider("PointsProvider", PointsProvider)
+    return prvd.new("PointsProvider", PointsProvider)
     ```
 
 === "TypeScript"
@@ -26,23 +26,18 @@ lifecycle events:
     ```TypeScript
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("PointsProvider", {})
+    @Provider({})
+    export class PointsProvider {}
     ```
 
-??? tip "Too verbose?"
+!!! warning "Know the difference"
 
-    If writing `prvd.Provider` sounds verbose for you, Oh My Prvd aliases the
-    `Provider` constructor with `.new`.
+    Both `prvd.new(name, provider)` and `@Provider(options)` seems to serve the
+    same purpose. The former is used as a function, ideal for Luau. Contrast to
+    the latter, used as a class decorator for Roblox TypeScript.
 
-    ```Lua
-    local ReplicatedStorage = game:GetService("ReplicatedStorage")
-    local prvd = require(ReplicatedStorage.Packages.ohmyprvd)
-
-    local PointsProvider = {}
-    return prvd.new("PointsProvider", PointsProvider)
-    ```
-
-    For consistency, we recommend using `Provider` when favorable.
+    If you're writing TypeScript, you should use the `@Provider(options)`
+    decorator. Otherwise, prefer to use `prvd.new(name, provider)`.
 
 The `name` argument signifies what to identify your provider as. This name must
 be unique from all other providers. Ideally, you should name your variable the
@@ -80,9 +75,10 @@ a `Player` and their points:
     ```TypeScript hl_lines="4"
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("PointsProvider", {
-      points: Map<Player, number> = {}
-    })
+    @Provider({})
+    export class PointsProvider {
+      public readonly points: Map<Player, number> = {}
+    }
     ```
 
 To instantiate our `points`, let's also implement a `setDefaultPoints` method
@@ -112,16 +108,17 @@ for convenience:
 
 === "TypeScript"
 
-    ```TypeScript hl_lines="6-8"
+    ```TypeScript hl_lines="7-9"
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("PointsProvider", {
-      points: Map<Player, number> = {}
+    @Provider({})
+    export class PointsProvider {
+      public readonly points: Map<Player, number> = {}
 
       setDefaultPoints(player: Player) {
         this.points.get(player)?.set(10)
       }
-    })
+    }
     ```
 
 Take a step back, and review what we wrote.
@@ -248,11 +245,12 @@ every player that joins:
 
 === "TypeScript"
 
-    ```TypeScript hl_lines="2 11-18"
-    import { Provider } from "@rbxts/ohmyprvd"
+    ```TypeScript hl_lines="2 5 11-18"
+    import { Provider, type OnStart } from "@rbxts/ohmyprvd"
     import { Players } from "@rbxts/services"
 
-    export = Provider("PointsProvider", {
+    @Provider({})
+    export class PointsProvider implements OnStart {
       points: Map<Player, number> = {},
 
       setDefaultPoints(player: Player) {
@@ -267,7 +265,7 @@ every player that joins:
           this.setDefaultPoints(existingPlayer)
         }
       }
-    })
+    }
     ```
 
 ---
@@ -355,7 +353,8 @@ First, create a file for a new `MathProvider` with the following:
     ```TypeScript
     import { Provider } from "@rbxts/ohmyprvd"
 
-    export = Provider("MathProvider", {
+    @Provider({})
+    export class MathProvider {
       add(a: number, b: number) {
         // this method is very expensive!
         task.wait(5)
@@ -420,7 +419,7 @@ end
 return prvd.Provider("PointsProvider", PointsProvider)
 ```
 
-??? danger "Do not use dependencies outside of lifecycle methods!"
+!!! danger "Do not use dependencies outside of lifecycle methods!"
 
     Oh My Prvd only returns a shadow of the `use()`d provider. You *cannot* use
     it outside of lifecycle methods.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Providers:
         - reference/core/providers/index.md
         - awaitStart: reference/core/providers/await-start.md
+        - new: reference/core/providers/new.md
         - onStart: reference/core/providers/on-start.md
         - preload: reference/core/providers/preload.md
         - Provider: reference/core/providers/provider.md

--- a/packages/ohmyprvd/lib/index.d.ts
+++ b/packages/ohmyprvd/lib/index.d.ts
@@ -105,13 +105,13 @@ declare namespace ohmyprvd {
 	export const onStart: (callback: () => void) => void
 
 	/**
-	 * Constructs and returns a new provider within Oh My Prvd. Providers must be
-	 * created before calling prvd.start(options).
+	 * Returns a decorator for providers. Intended to be used by TypeScript
+	 * classes, where `prvd.new` may be unideal as a reserved keyword and subpar
+	 * syntax.
 	 */
-	export const Provider: <T extends object>(
-		name: string,
-		provider: Provider<T>,
-	) => Provider<T>
+	export const Provider: (options?: {
+		loadOrder?: number
+	}) => <T extends new () => InstanceType<T>>(provider: T) => void
 
 	/**
 	 * Uses a provider within Oh My Prvd. During ignition, Oh My Prvd will inject

--- a/packages/ohmyprvd/lib/init.luau
+++ b/packages/ohmyprvd/lib/init.luau
@@ -40,9 +40,8 @@ local prvd: types.Prvd = table.freeze {
 
   -- Core API
   awaitStart = prvd.awaitStart,
-  new = prvd.Provider,
+  new = prvd.new,
   onStart = prvd.onStart,
-  Provider = prvd.Provider,
   StartupStatus = prvd.StartupStatus,
   start = prvd.start,
   use = prvd.use,
@@ -62,6 +61,9 @@ local prvd: types.Prvd = table.freeze {
 
   -- Utility APIs
   preload = utils.preload,
+
+  -- TypeScript APIs
+  Provider = prvd.Provider,
 }
 
 return prvd

--- a/packages/ohmyprvd/lib/prvd.luau
+++ b/packages/ohmyprvd/lib/prvd.luau
@@ -37,12 +37,17 @@ local expect = log.expect
 local parseError = log.parseError
 local throw = log.throw
 
-export type Error = types.Error
-export type OnInit = types.OnInit
-export type OnStart = types.OnStart
-export type Options = types.Options
-export type Provider<T> = types.Provider<T>
-export type StartupStatus = types.StartupStatus
+type Error = types.Error
+type OnInit = types.OnInit
+type OnStart = types.OnStart
+type Options = types.Options
+type Provider<T> = types.Provider<T>
+type StartupStatus = types.StartupStatus
+
+local PROVIDER_DECORATOR = newproxy(true)
+getmetatable(PROVIDER_DECORATOR).__tostring = function()
+  return "prvd.PROVIDER_DECORATOR"
+end
 
 local WEAK_KEYS_METATABLE = { __mode = "k" }
 
@@ -132,7 +137,7 @@ end
   Constructs and returns a new provider within Oh My Prvd. Providers must be
   created before calling `Prvd.start()`.
 ]]
-function prvd.Provider<T>(name: string, provider: T): Provider<T>
+function prvd.new<T>(name: string, provider: T): Provider<T>
   expect(status == StartupStatus.Pending, "registerAfterStarted")
   expect(typeof(name) == "string", "cannotRegister", nil, "`name` must be a string")
   expect(name:len() > 0, "cannotRegister", nil, "`name` cannot be empty")
@@ -155,6 +160,34 @@ function prvd.Provider<T>(name: string, provider: T): Provider<T>
   providers[name] = provider
   modding.doProviderConstructed(provider)
   return provider
+end
+
+--[[
+  Returns a decorator for providers. Intended to be used by TypeScript classes,
+  where `prvd.new` may be unideal as a reserved keyword and subpar syntax.
+]]
+function prvd.Provider(options: { loadOrder: number? }?)
+  local options = options or {}
+  return function<T>(provider: T)
+    expect(typeof(provider) == "table", "cannotRegister", nil, "provider must be a table")
+    expect(not table.isfrozen(provider :: any), "cannotRegister", nil, "provider cannot be frozen")
+    expect(typeof(provider.new) == "function", "cannotRegister", nil, "must use TypeScript decorator on a class")
+    expect(typeof(provider.__tostring) == "function", "cannotRegister", nil, "must use TypeScript decorator on a class")
+
+    local newProvider = provider.new()
+
+    local name = provider:__tostring()
+    expect(typeof(name) == "string", "cannotRegister", nil, `expected provider class tostring to return a string`)
+    expect(typeof(name) == "string", "cannotRegister", nil, "`name` must be a string")
+    expect(name:len() > 0, "cannotRegister", nil, "`name` cannot be empty")
+
+    reflect.defineMetadata(newProvider, "ohmyprvd:provider", true)
+    reflect.defineMetadata(newProvider, "identifier", name)
+    reflect.defineMetadata(newProvider, "ohmyprvd:loadOrder", options.loadOrder)
+
+    providers[name] = newProvider
+    modding.doProviderConstructed(newProvider)
+  end
 end
 
 --[[

--- a/packages/ohmyprvd/lib/types.luau
+++ b/packages/ohmyprvd/lib/types.luau
@@ -94,7 +94,7 @@ export type Prvd = {
   },
   new: <T>(name: string, provider: T) -> Provider<T>,
   onStart: (callback: () -> ()) -> (),
-  Provider: <T>(name: string, provider: T) -> Provider<T>,
+  Provider: (options: { loadOrder: number? }?) -> <T>(provider: T) -> (),
   use: <T>(provider: Provider<T>) -> T,
 
   onMethodImplemented: (method: string, handler: (Provider<unknown>) -> ()) -> (),


### PR DESCRIPTION
Solves #6. Splits `prvd.new` and `prvd.Provider`, the former for Luau and the latter for TypeScript as a decorator.